### PR TITLE
Climbing Chalk

### DIFF
--- a/plugins/Denizen/scripts/climbing_chalk.dsc
+++ b/plugins/Denizen/scripts/climbing_chalk.dsc
@@ -1,71 +1,90 @@
 climbing_chalk:
     type: item
-    debug: false
     material: sugar
     allow in material recipes: false
     display name: <dark_aqua>Climbing Chalk
     lore:
-    - <&7>Strengthens your grip.
+    - <gold>Strengthens your grip.
     - <&7>Allows you to climb on fences, inner walls, buttons, chains, and iron bars.
     - <&7>Lasts 5 minutes.
-    - <&7>Sneak + Right Click in air to apply.
+    - <&7><&keybind[key.sneak]> + <&keybind[key.use]> in air to apply.
     recipes:
         1:
             type: shapeless
             output_quantity: 4
             input: calcite
 
+climbing_chalk_config:
+    type: data
+    colors:
+        chalk_sufficient_warning: red
+        chalk_low_warning: red
+        chalk_out_warning: red
+        chalk_applied: aqua
+
 climbing_chalk_handler:
     type: world
     debug: false
     events:
-        on player right clicks air with:climbing_chalk flagged:climbing_chalk_active:
+        on server start:
+        - flag server climbable_materials:<server.vanilla_tagged_materials[climbable].include[iron_bars|chain].include[<server.vanilla_tagged_materials[walls]>].include[<server.vanilla_tagged_materials[fences]>].include[<server.vanilla_tagged_materials[buttons]>]>
+        on player right clicks air with:climbing_chalk:
         - ratelimit <player> 1t
-        - if <player.flag_expiration[climbing_chalk_active].duration_since[<util.time_now>].is_more_than[30s]>:
-            - narrate "<red>You have enough chalk for the moment."
-            - stop
-        - take iteminhand quantity:1
-        - flag <player> climbing_chalk_active expire:<player.flag_expiration[climbing_chalk_active].add[5m]>
-        - narrate "<aqua>You apply more chalk to your hands."
-        - runlater climbing_chalk_low def:<player> delay:<player.flag_expiration[climbing_chalk_active].duration_since[<util.time_now>].sub[30s]>
-        on player right clicks air with:climbing_chalk flagged:!climbing_chalk_active:
-        - ratelimit <player> 1t
-        - take iteminhand quantity:1
-        - flag <player> climbing_chalk_active expire:5m
-        - adjust <player> send_climbable_materials:<server.vanilla_tagged_materials[climbable].include[iron_bars|chain].include[<server.vanilla_tagged_materials[walls]>].include[<server.vanilla_tagged_materials[fences]>].include[<server.vanilla_tagged_materials[buttons]>]>
-        - narrate "<aqua>You feel your grip strengthen."
-        - runlater climbing_chalk_low def:<player> delay:270s
-        on player quits flagged:climbing_chalk_active:
-        - if <player.flag_expiration[climbing_chalk_active].duration_since[<util.time_now>].is_less_than[30s]>:
-            - flag <player> climbing_chalk_active:!
-            - stop
-        - flag <player> climbing_chalk_offline_save:<player.flag_expiration[climbing_chalk_active].duration_since[<util.time_now>]>
-        - flag <player> climbing_chalk_active:!
+        - if <player.is_sneaking>:
+            - run climbing_chalk_add_time def:<player>
+        on player quits flagged:climbing_chalk.active:
+        - run climbing_chalk_save_duration def:<player>
         on shutdown:
-        - foreach <server.online_players_flagged[climbing_chalk_active]> as:plyr:
-            - if <[plyr].flag_expiration[climbing_chalk_active].duration_since[<util.time_now>].is_less_than[30s]>:
-                - flag <[plyr]> climbing_chalk_active:!
-                - stop
-            - flag <[plyr]> climbing_chalk_offline_save:<[plyr].flag_expiration[climbing_chalk_active].duration_since[<util.time_now>]>
-            - flag <[plyr]> climbing_chalk_active:!
-        after player joins flagged:climbing_chalk_offline_save:
-        - flag <player> climbing_chalk_active expire:<player.flag[climbing_chalk_offline_save]>
-        - runlater climbing_chalk_low def:<player> delay:<player.flag[climbing_chalk_offline_save].sub[30s]>
-        - flag <player> climbing_chalk_offline_save:!
-        - adjust <player> send_climbable_materials:<server.vanilla_tagged_materials[climbable].include[iron_bars|chain].include[<server.vanilla_tagged_materials[walls]>].include[<server.vanilla_tagged_materials[fences]>].include[<server.vanilla_tagged_materials[buttons]>]>
-        - narrate "<aqua>You sense your grip retains its strength."
+        - foreach <server.online_players_flagged[climbing_chalk.active]> as:__player:
+            - run climbing_chalk_save_duration def:<player>
+        after player joins flagged:climbing_chalk.offline_save:
+        - flag <player> climbing_chalk.active expire:<player.flag[climbing_chalk.offline_save]>
+        - runlater climbing_chalk_low def:<player> delay:<player.flag[climbing_chalk.offline_save].sub[30s]>
+        - flag <player> climbing_chalk.offline_save:!
+        - adjust <player> send_climbable_materials:<server.flag[climbable_materials]
+        - narrate "<&color[<script[climbing_chalk_config].data_key[colors.chalk_applied]>]>You sense your grip retains its strength."
         after server resources reloaded:
-        - foreach <server.online_players_flagged[climbing_chalk_active]> as:plyr:
-            - adjust <[plyr]> send_climbable_materials:<server.vanilla_tagged_materials[climbable].include[iron_bars|chain].include[<server.vanilla_tagged_materials[walls]>].include[<server.vanilla_tagged_materials[fences]>].include[<server.vanilla_tagged_materials[buttons]>]>
+        - foreach <server.online_players_flagged[climbing_chalk.active]> as:plyr:
+            - adjust <player> send_climbable_materials:<server.flag[climbable_materials]>
+
+climbing_chalk_add_time:
+    type: task
+    debug: false
+    definitions: plyr
+    script:
+    - define chalk_duration 5m
+    - if <[plyr].flag[climbing_chalk.active].exists>:
+        - if <[plyr].flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].is_more_than[30s]>:
+            - narrate "<&color[<script[climbing_chalk_config].data_key[colors.chalk_sufficient_warning]>]>You have enough chalk for the moment."
+            - stop
+        - define chalk_duration <[plyr].flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].add[5m]>
+    - if <[plyr].flag[climbing_chalk.offline_save].exists>:
+        - define chalk_duration <[plyr].flag[climbing_chalk.offline_save]>
+    - take item:climbing_chalk quantity:1 from:<[plyr].inventory>
+    - flag <[plyr]> climbing_chalk.active expire:<[chalk_duration]>
+    - adjust <[plyr]> send_climbable_materials:<server.flag[climbable_materials]>
+    - narrate "<&color[<script[climbing_chalk_config].data_key[colors.chalk_applied]>]>You apply some chalk to your hands, strengthening your grip."
+    - runlater climbing_chalk_low def:<[plyr]> delay:<[plyr].flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].sub[30s]>
+
+climbing_chalk_save_duration:
+    type: task
+    debug: false
+    definitions: plyr
+    script:
+    - if <[plyr].flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].is_less_than[30s]>:
+        - flag <[plyr]> climbing_chalk.active:!
+        - stop
+    - flag <[plyr]> climbing_chalk.offline_save:<[plyr].flag_expiration[climbing_chalk.active].duration_since[<util.time_now>]>
+    - flag <[plyr]> climbing_chalk.active:!
 
 climbing_chalk_low:
     type: task
     debug: false
     definitions: plyr
     script:
-    - if !<[plyr].is_online> || <[plyr].flag_expiration[climbing_chalk_active].duration_since[<util.time_now>].is_more_than[30s]>:
+    - if not <[plyr].is_online> or <[plyr].flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].is_more_than[30s]>:
         - stop
-    - narrate targets:<[plyr]> "<red>You feel your grip begin to weaken."
+    - narrate targets:<[plyr]> "<&color[<script[climbing_chalk_config].data_key[colors.chalk_low_warning]>]>You feel your grip begin to weaken."
     - runlater climbing_chalk_out def:<[plyr]> delay:31s
 
 climbing_chalk_out:
@@ -73,7 +92,7 @@ climbing_chalk_out:
     debug: false
     definitions: plyr
     script:
-    - if !<[plyr].is_online> || <[plyr].flag[climbing_chalk_active].exists>:
+    - if not <[plyr].is_online> or <[plyr].flag[climbing_chalk.active].exists>:
         - stop
-    - narrate targets:<[plyr]> "<red>You have run out of chalk."
+    - narrate targets:<[plyr]> "<&color[<script[climbing_chalk_config].data_key[colors.chalk_out_warning]>]>You have run out of chalk."
     - adjust <[plyr]> send_climbable_materials:<server.vanilla_tagged_materials[climbable]>

--- a/plugins/Denizen/scripts/climbing_chalk.dsc
+++ b/plugins/Denizen/scripts/climbing_chalk.dsc
@@ -1,0 +1,79 @@
+climbing_chalk:
+    type: item
+    debug: false
+    material: sugar
+    allow in material recipes: false
+    display name: <dark_aqua>Climbing Chalk
+    lore:
+    - <&7>Strengthens your grip.
+    - <&7>Allows you to climb on fences, inner walls, buttons, chains, and iron bars.
+    - <&7>Lasts 5 minutes.
+    - <&7>Sneak + Right Click in air to apply.
+    recipes:
+        1:
+            type: shapeless
+            output_quantity: 4
+            input: calcite
+
+climbing_chalk_handler:
+    type: world
+    debug: false
+    events:
+        on player right clicks air with:climbing_chalk flagged:climbing_chalk_active:
+        - ratelimit <player> 1t
+        - if <player.flag_expiration[climbing_chalk_active].duration_since[<util.time_now>].is_more_than[30s]>:
+            - narrate "<red>You have enough chalk for the moment."
+            - stop
+        - take iteminhand quantity:1
+        - flag <player> climbing_chalk_active expire:<player.flag_expiration[climbing_chalk_active].add[5m]>
+        - narrate "<aqua>You apply more chalk to your hands."
+        - runlater climbing_chalk_low def:<player> delay:<player.flag_expiration[climbing_chalk_active].duration_since[<util.time_now>].sub[30s]>
+        on player right clicks air with:climbing_chalk flagged:!climbing_chalk_active:
+        - ratelimit <player> 1t
+        - take iteminhand quantity:1
+        - flag <player> climbing_chalk_active expire:5m
+        - adjust <player> send_climbable_materials:<server.vanilla_tagged_materials[climbable].include[iron_bars|chain].include[<server.vanilla_tagged_materials[walls]>].include[<server.vanilla_tagged_materials[fences]>].include[<server.vanilla_tagged_materials[buttons]>]>
+        - narrate "<aqua>You feel your grip strengthen."
+        - runlater climbing_chalk_low def:<player> delay:270s
+        on player quits flagged:climbing_chalk_active:
+        - if <player.flag_expiration[climbing_chalk_active].duration_since[<util.time_now>].is_less_than[30s]>:
+            - flag <player> climbing_chalk_active:!
+            - stop
+        - flag <player> climbing_chalk_offline_save:<player.flag_expiration[climbing_chalk_active].duration_since[<util.time_now>]>
+        - flag <player> climbing_chalk_active:!
+        on shutdown:
+        - foreach <server.online_players_flagged[climbing_chalk_active]> as:plyr:
+            - if <[plyr].flag_expiration[climbing_chalk_active].duration_since[<util.time_now>].is_less_than[30s]>:
+                - flag <[plyr]> climbing_chalk_active:!
+                - stop
+            - flag <[plyr]> climbing_chalk_offline_save:<[plyr].flag_expiration[climbing_chalk_active].duration_since[<util.time_now>]>
+            - flag <[plyr]> climbing_chalk_active:!
+        after player joins flagged:climbing_chalk_offline_save:
+        - flag <player> climbing_chalk_active expire:<player.flag[climbing_chalk_offline_save]>
+        - runlater climbing_chalk_low def:<player> delay:<player.flag[climbing_chalk_offline_save].sub[30s]>
+        - flag <player> climbing_chalk_offline_save:!
+        - adjust <player> send_climbable_materials:<server.vanilla_tagged_materials[climbable].include[iron_bars|chain].include[<server.vanilla_tagged_materials[walls]>].include[<server.vanilla_tagged_materials[fences]>].include[<server.vanilla_tagged_materials[buttons]>]>
+        - narrate "<aqua>You sense your grip retains its strength."
+        after server resources reloaded:
+        - foreach <server.online_players_flagged[climbing_chalk_active]> as:plyr:
+            - adjust <[plyr]> send_climbable_materials:<server.vanilla_tagged_materials[climbable].include[iron_bars|chain].include[<server.vanilla_tagged_materials[walls]>].include[<server.vanilla_tagged_materials[fences]>].include[<server.vanilla_tagged_materials[buttons]>]>
+
+climbing_chalk_low:
+    type: task
+    debug: false
+    definitions: plyr
+    script:
+    - if !<[plyr].is_online> || <[plyr].flag_expiration[climbing_chalk_active].duration_since[<util.time_now>].is_more_than[30s]>:
+        - stop
+    - narrate targets:<[plyr]> "<red>You feel your grip begin to weaken."
+    - runlater climbing_chalk_out def:<[plyr]> delay:31s
+
+climbing_chalk_out:
+    type: task
+    debug: false
+    definitions: plyr
+    script:
+    - if !<[plyr].is_online> || <[plyr].flag[climbing_chalk_active].exists>:
+        - stop
+    - narrate targets:<[plyr]> "<red>You have run out of chalk."
+    - adjust <[plyr]> send_climbable_materials:<server.vanilla_tagged_materials[climbable]>

--- a/plugins/Denizen/scripts/climbing_chalk.dsc
+++ b/plugins/Denizen/scripts/climbing_chalk.dsc
@@ -2,25 +2,17 @@ climbing_chalk:
     type: item
     material: sugar
     allow in material recipes: false
-    display name: <dark_aqua>Climbing Chalk
+    display name: <&[item]>Climbing Chalk
     lore:
-    - <gold>Strengthens your grip.
-    - <&7>Allows you to climb on fences, inner walls, buttons, chains, and iron bars.
-    - <&7>Lasts 5 minutes.
-    - <&7><&keybind[key.sneak]> + <&keybind[key.use]> in air to apply.
+    - <&[emphasis]>Strengthens your grip.
+    - <&[lore]>Allows you to climb on fences, inner walls, buttons, chains, and iron bars.
+    - <&[lore]>Lasts 5 minutes.
+    - <&[lore]><&keybind[key.sneak]> + <&keybind[key.use]> in air to apply.
     recipes:
         1:
             type: shapeless
             output_quantity: 4
             input: calcite
-
-climbing_chalk_config:
-    type: data
-    colors:
-        chalk_sufficient_warning: red
-        chalk_low_warning: red
-        chalk_out_warning: red
-        chalk_applied: aqua
 
 climbing_chalk_handler:
     type: world
@@ -31,18 +23,18 @@ climbing_chalk_handler:
         on player right clicks air with:climbing_chalk:
         - ratelimit <player> 1t
         - if <player.is_sneaking>:
-            - run climbing_chalk_add_time def:<player>
+            - run climbing_chalk_add_time
         on player quits flagged:climbing_chalk.active:
-        - run climbing_chalk_save_duration def:<player>
+        - run climbing_chalk_save_duration
         on shutdown:
         - foreach <server.online_players_flagged[climbing_chalk.active]> as:__player:
-            - run climbing_chalk_save_duration def:<player>
+            - run climbing_chalk_save_duration
         after player joins flagged:climbing_chalk.offline_save:
         - flag <player> climbing_chalk.active expire:<player.flag[climbing_chalk.offline_save]>
-        - runlater climbing_chalk_low def:<player> delay:<player.flag[climbing_chalk.offline_save].sub[30s]>
+        - runlater climbing_chalk_low delay:<player.flag[climbing_chalk.offline_save].sub[30s]>
         - flag <player> climbing_chalk.offline_save:!
-        - adjust <player> send_climbable_materials:<server.flag[climbable_materials]
-        - narrate "<&color[<script[climbing_chalk_config].data_key[colors.chalk_applied]>]>You sense your grip retains its strength."
+        - adjust <player> send_climbable_materials:<server.flag[climbable_materials]>
+        - narrate "<&[emphasis]>You sense your grip retains its strength."
         after server resources reloaded:
         - foreach <server.online_players_flagged[climbing_chalk.active]> as:plyr:
             - adjust <player> send_climbable_materials:<server.flag[climbable_materials]>
@@ -50,49 +42,45 @@ climbing_chalk_handler:
 climbing_chalk_add_time:
     type: task
     debug: false
-    definitions: plyr
     script:
     - define chalk_duration 5m
-    - if <[plyr].flag[climbing_chalk.active].exists>:
-        - if <[plyr].flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].is_more_than[30s]>:
-            - narrate "<&color[<script[climbing_chalk_config].data_key[colors.chalk_sufficient_warning]>]>You have enough chalk for the moment."
+    - if <player.flag[climbing_chalk.active].exists>:
+        - if <player.flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].is_more_than[30s]>:
+            - narrate "<&[error]>You have enough chalk for the moment."
             - stop
-        - define chalk_duration <[plyr].flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].add[5m]>
-    - if <[plyr].flag[climbing_chalk.offline_save].exists>:
-        - define chalk_duration <[plyr].flag[climbing_chalk.offline_save]>
-    - take item:climbing_chalk quantity:1 from:<[plyr].inventory>
-    - flag <[plyr]> climbing_chalk.active expire:<[chalk_duration]>
-    - adjust <[plyr]> send_climbable_materials:<server.flag[climbable_materials]>
-    - narrate "<&color[<script[climbing_chalk_config].data_key[colors.chalk_applied]>]>You apply some chalk to your hands, strengthening your grip."
-    - runlater climbing_chalk_low def:<[plyr]> delay:<[plyr].flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].sub[30s]>
+        - define chalk_duration <player.flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].add[5m]>
+    - if <player.flag[climbing_chalk.offline_save].exists>:
+        - define chalk_duration <player.flag[climbing_chalk.offline_save]>
+    - take item:climbing_chalk quantity:1 from:<player.inventory>
+    - flag <player> climbing_chalk.active expire:<[chalk_duration]>
+    - adjust <player> send_climbable_materials:<server.flag[climbable_materials]>
+    - narrate "<&[emphasis]>You apply some chalk to your hands, strengthening your grip."
+    - runlater climbing_chalk_low delay:<player.flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].sub[30s]>
 
 climbing_chalk_save_duration:
     type: task
     debug: false
-    definitions: plyr
     script:
-    - if <[plyr].flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].is_less_than[30s]>:
-        - flag <[plyr]> climbing_chalk.active:!
+    - if <player.flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].is_less_than[30s]>:
+        - flag <player> climbing_chalk.active:!
         - stop
-    - flag <[plyr]> climbing_chalk.offline_save:<[plyr].flag_expiration[climbing_chalk.active].duration_since[<util.time_now>]>
-    - flag <[plyr]> climbing_chalk.active:!
+    - flag <player> climbing_chalk.offline_save:<player.flag_expiration[climbing_chalk.active].duration_since[<util.time_now>]>
+    - flag <player> climbing_chalk.active:!
 
 climbing_chalk_low:
     type: task
     debug: false
-    definitions: plyr
     script:
-    - if not <[plyr].is_online> or <[plyr].flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].is_more_than[30s]>:
+    - if not <player.is_online> or <player.flag_expiration[climbing_chalk.active].duration_since[<util.time_now>].is_more_than[30s]>:
         - stop
-    - narrate targets:<[plyr]> "<&color[<script[climbing_chalk_config].data_key[colors.chalk_low_warning]>]>You feel your grip begin to weaken."
-    - runlater climbing_chalk_out def:<[plyr]> delay:31s
+    - narrate targets:<player> "<&[warning]>You feel your grip begin to weaken."
+    - runlater climbing_chalk_out delay:31s
 
 climbing_chalk_out:
     type: task
     debug: false
-    definitions: plyr
     script:
-    - if not <[plyr].is_online> or <[plyr].flag[climbing_chalk.active].exists>:
+    - if not <player.is_online> or <player.flag[climbing_chalk.active].exists>:
         - stop
-    - narrate targets:<[plyr]> "<&color[<script[climbing_chalk_config].data_key[colors.chalk_out_warning]>]>You have run out of chalk."
-    - adjust <[plyr]> send_climbable_materials:<server.vanilla_tagged_materials[climbable]>
+    - narrate targets:<player> "<&[warning]>You have run out of chalk."
+    - adjust <player> send_climbable_materials:<server.vanilla_tagged_materials[climbable]>


### PR DESCRIPTION
Climbing chalk allows you to climb on iron bars, chains, fences, buttons, and the inner part of walls (not posts).

- One piece of Calcite in a crafting table nets you four pieces of climbing chalk.
- Climbing chalk lasts for five minutes, and gives you a warning when only thirty seconds remain.
- Climbing chalk status is saved on server shutdown, and player log outs, however if less than thirty seconds of time remains, it will be lost.